### PR TITLE
define fuels version in workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/forc"
+
+[workspace.dependencies]
+fuels = "0.75"

--- a/forc-wallet/Cargo.toml
+++ b/forc-wallet/Cargo.toml
@@ -19,7 +19,7 @@ eth-keystore = { version = "0.5" }
 forc-tracing = "0.68"
 
 # Dependencies from the `fuels-rs` repository:
-fuels = "0.75"
+fuels.workspace = true
 
 futures = "0.3"
 hex = "0.4"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves `fuels` version to `[workspace.dependencies]` and updates `forc-wallet` to use the workspace dependency.
> 
> - **Workspace**:
>   - Add `fuels = "0.75"` under `[workspace.dependencies]` in `Cargo.toml`.
> - **forc-wallet**:
>   - Replace direct `fuels = "0.75"` with `fuels.workspace = true` in `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 248be968d86afbe6cbe89694ab20c1f5ec519e03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->