### PR TITLE
bump forc-wallet 0.16.1

### DIFF
--- a/forc-wallet/CHANGELOG.md
+++ b/forc-wallet/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.16.1 (November 21st, 2025)
+
+### Changed
+
+- deps: added fuels to the workspace dependencies
+
 # 0.16.0 (November 21st, 2025)
 
 ### Changed

--- a/forc-wallet/Cargo.toml
+++ b/forc-wallet/Cargo.toml
@@ -4,7 +4,7 @@ name = "forc-wallet"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "forc-wallet-0.16.x" git tag.
-version = "0.16.0"
+version = "0.16.1"
 description = "A forc plugin for generating or importing wallets using mnemonic phrases."
 edition = "2024"
 authors.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `forc-wallet` to 0.16.1 and updates the changelog noting a workspace dependency addition.
> 
> - **Release**:
>   - Bump `forc-wallet` version to `0.16.1` in `forc-wallet/Cargo.toml`.
> - **Changelog**:
>   - Add `0.16.1` entry noting workspace dependency update in `forc-wallet/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3078989508f25eb0c37fb843525614b7d4364f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->