### PR TITLE
fix: use cargo publish directly instead of publish-crates action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,7 @@ jobs:
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }}
 
       - name: Publish crate
-        uses: FuelLabs/publish-crates@v1
-        with:
-          path: ./${{ steps.extract_crate.outputs.crate_name }}
-          publish-delay: 30000
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p ${{ steps.extract_crate.outputs.crate_name }} --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v1


### PR DESCRIPTION
The FuelLabs/publish-crates action checks all workspace members for consistency even with path parameter. Use `cargo publish -p` directly to only publish the specific crate from the tag.