### PR TITLE
fix: improve releases.toml automation for accurate dependency tracking

### DIFF
--- a/releases.toml
+++ b/releases.toml
@@ -7,3 +7,10 @@ version = "0.16.2"
 date = "2025-12-07"
 fuels-rs = "0.75.0"
 
+[[releases]]
+crate = "forc-crypto"
+version = "0.71.0"
+date = "2025-12-08"
+fuel-core-types = "0.47.1"
+fuels-rs = "0.76.0"
+


### PR DESCRIPTION
## Summary

Fixes several issues with the `releases.toml` automation:

- **Wrong versions**: Used `grep` on Cargo.lock which grabbed the first match when multiple versions exist (e.g., returned 0.46.0 instead of 0.47.1 for fuel-core-types). Now uses `cargo metadata` for accurate resolution.

- **Missing dependencies**: Only tracked `fuel-core` and `fuels`, missing crates that use `fuel-core-types`, `fuels-core`, or `fuels-accounts` directly.

- **Unnecessary PRs**: Created empty entries for crates with no tracked dependencies (like forc-tracing), triggering PRs that shouldn't exist. Now skips these entirely.

Also adds the correct `forc-crypto-0.71.0` release entry.

## Context

See #125 (forc-tracing release that shouldn't have triggered a releases.toml PR) and #126 (forc-crypto PR that had incomplete dependency info).