### PR TITLE
fix: handle crates with multiple binary targets in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,17 @@ jobs:
           if [ -f "${CRATE_NAME}/src/main.rs" ] || grep -q '^\[\[bin\]\]' "${CRATE_NAME}/Cargo.toml" 2>/dev/null; then
             echo "has_binary=true" >> $GITHUB_OUTPUT
             echo "Crate $CRATE_NAME has binary target"
+
+            # Extract binary names from Cargo.toml
+            if grep -q '^\[\[bin\]\]' "${CRATE_NAME}/Cargo.toml" 2>/dev/null; then
+              # Extract all binary names from [[bin]] sections
+              BINARIES=$(grep -A3 '^\[\[bin\]\]' "${CRATE_NAME}/Cargo.toml" | grep '^name' | sed 's/name = "\([^"]*\)"/\1/' | tr '\n' ' ')
+            else
+              # Default to crate name if using src/main.rs
+              BINARIES="$CRATE_NAME"
+            fi
+            echo "binaries=$BINARIES" >> $GITHUB_OUTPUT
+            echo "Binary targets: $BINARIES"
           else
             echo "has_binary=false" >> $GITHUB_OUTPUT
             echo "Crate $CRATE_NAME is library-only, skipping binary build"
@@ -280,20 +291,28 @@ jobs:
 
       - name: Strip release binary x86_64-linux-gnu
         if: steps.check_binary.outputs.has_binary == 'true' && matrix.job.target == 'x86_64-unknown-linux-gnu'
-        run: strip "target/${{ matrix.job.target }}/release/${{ steps.extract_crate.outputs.crate_name }}"
+        run: |
+          for bin in ${{ steps.check_binary.outputs.binaries }}; do
+            strip "target/${{ matrix.job.target }}/release/$bin"
+          done
 
       - name: Strip release binary aarch64-linux-gnu
         if: steps.check_binary.outputs.has_binary == 'true' && matrix.job.target == 'aarch64-unknown-linux-gnu'
         run: |
-          docker run --rm -v \
-          "$PWD/target:/target:Z" \
-          ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main \
-          aarch64-linux-gnu-strip \
-          /target/aarch64-unknown-linux-gnu/release/${{ steps.extract_crate.outputs.crate_name }}
+          for bin in ${{ steps.check_binary.outputs.binaries }}; do
+            docker run --rm -v \
+            "$PWD/target:/target:Z" \
+            ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main \
+            aarch64-linux-gnu-strip \
+            /target/aarch64-unknown-linux-gnu/release/$bin
+          done
 
       - name: Strip release binary mac
         if: steps.check_binary.outputs.has_binary == 'true' && matrix.job.os == 'macos-latest'
-        run: strip -x "target/${{ matrix.job.target }}/release/${{ steps.extract_crate.outputs.crate_name }}"
+        run: |
+          for bin in ${{ steps.check_binary.outputs.binaries }}; do
+            strip -x "target/${{ matrix.job.target }}/release/$bin"
+          done
 
       - name: Prep assets
         if: steps.check_binary.outputs.has_binary == 'true'
@@ -303,6 +322,7 @@ jobs:
           TARGET: ${{ matrix.job.target }}
           TARGET_SUFFIX: ${{ matrix.job.target_suffix }}
           CRATE_NAME: ${{ steps.extract_crate.outputs.crate_name }}
+          BINARIES: ${{ steps.check_binary.outputs.binaries }}
         run: |
           # Get tag name
           # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
@@ -314,7 +334,9 @@ jobs:
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
           # create zip file
           mkdir -pv "$ARTIFACT"
-          cp "target/${{ matrix.job.target }}/release/${CRATE_NAME}" "$ARTIFACT"
+          for bin in $BINARIES; do
+            cp "target/${{ matrix.job.target }}/release/$bin" "$ARTIFACT"
+          done
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
       - name: Upload release archive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.71.0"
+version = "0.71.1"
 dependencies = [
  "ansiterm",
  "anyhow",

--- a/forc-client/CHANGELOG.md
+++ b/forc-client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.71.1 (February 4th, 2026)
+
+- First release from `FuelLabs/forc` repository
+
 # 0.71.0 (February 3rd, 2026)
 
 - Previous release from `FuelLabs/sway` repository

--- a/forc-client/Cargo.toml
+++ b/forc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.71.0"
+version = "0.71.1"
 edition = "2021"
 description = "A `forc` plugin for interacting with a Fuel node."
 authors.workspace = true


### PR DESCRIPTION
## Summary

Fixes the release workflow failing for `forc-client` because it produces multiple binaries (`forc-deploy`, `forc-run`, `forc-submit`, `forc-call`) rather than a single `forc-client` binary.

The workflow now:
- Extracts binary names from `[[bin]]` sections in `Cargo.toml`
- Falls back to crate name for crates using `src/main.rs`
- Iterates over each binary when stripping and packaging

When you release `forc-client-0.71.0`, it will create:

```
forc-client-0.71.0-linux_amd64.tar.gz
├── forc-deploy
├── forc-run
├── forc-submit
└── forc-call
```

## Context

- Failing run: https://github.com/FuelLabs/forc/actions/runs/21612021435/job/62282720383
- Previous PR that introduced forc-client: https://github.com/FuelLabs/forc/pull/143

## Test plan

- [x] Tested binary extraction logic locally for `forc-client`, `forc-crypto`, `forc-node`
- [ ] Verify CI passes on this PR
- [ ] Test with actual forc-client release