### PR TITLE
fix: use vendored OpenSSL for wallet 0.16.4 release hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,7 @@ dependencies = [
  "futures",
  "hex",
  "k256",
+ "openssl",
  "portpicker",
  "pretty_assertions",
  "rand 0.8.5",
@@ -3864,6 +3865,7 @@ dependencies = [
  "futures",
  "hex",
  "libp2p-identity",
+ "openssl",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -4081,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4092,6 +4094,7 @@ dependencies = [
  "futures",
  "hex",
  "home",
+ "openssl",
  "rand 0.8.5",
  "rpassword",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/FuelLabs/forc"
 [workspace.dependencies]
 # Internal dependencies
 forc-tracing = { version = "0.72.0", path = "forc-tracing" }
-forc-wallet = { version = "0.16.3", path = "forc-wallet" }
+forc-wallet = { version = "0.16.4", path = "forc-wallet" }
 
 # Sway dependencies (from crates.io)
 sway-core = "0.71.0"

--- a/forc-client/CHANGELOG.md
+++ b/forc-client/CHANGELOG.md
@@ -5,6 +5,10 @@
 - deps: update compatibility to `sway` 0.71.0, `fuel-core` 0.48, `fuel-vm` 0.66, and `fuels-rs` 0.77
 - internal: update trace storage handling for the `fuel-vm` 0.66 APIs
 
+### Fixed
+
+- Use vendored OpenSSL for cross-compilation to avoid system package dependencies
+
 # 0.71.1 (February 4th, 2026)
 
 - First release from `FuelLabs/forc` repository

--- a/forc-client/Cargo.toml
+++ b/forc-client/Cargo.toml
@@ -58,6 +58,7 @@ fuels-core.workspace = true
 futures.workspace = true
 hex.workspace = true
 k256.workspace = true
+openssl.workspace = true
 rand.workspace = true
 regex.workspace = true
 reqwest = { workspace = true }

--- a/forc-crypto/CHANGELOG.md
+++ b/forc-crypto/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - deps: update compatibility to `fuel-core` 0.48, `fuel-crypto` 0.66, and `fuels-rs` 0.77
 
+### Fixed
+
+- Use vendored OpenSSL for cross-compilation to avoid system package dependencies
+
 # 0.71.0 (December 8th, 2025)
 
 ### Changed

--- a/forc-crypto/Cargo.toml
+++ b/forc-crypto/Cargo.toml
@@ -29,6 +29,7 @@ fuels-core.workspace = true
 futures.workspace = true
 hex.workspace = true
 libp2p-identity = { workspace = true, features = ["peerid", "secp256k1"] }
+openssl.workspace = true
 rand.workspace = true
 rayon.workspace = true
 regex.workspace = true

--- a/forc-wallet/CHANGELOG.md
+++ b/forc-wallet/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.16.4 (April 20th, 2026)
+
+### Fixed
+
+- Use vendored OpenSSL for cross-compilation to avoid system package dependencies
+
 # 0.16.3 (April 7th, 2026)
 
 ### Changed

--- a/forc-wallet/Cargo.toml
+++ b/forc-wallet/Cargo.toml
@@ -4,7 +4,7 @@ name = "forc-wallet"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "forc-wallet-0.16.x" git tag.
-version = "0.16.3"
+version = "0.16.4"
 description = "A forc plugin for generating or importing wallets using mnemonic phrases."
 edition = "2024"
 authors.workspace = true
@@ -25,6 +25,7 @@ fuels.workspace = true
 futures.workspace = true
 hex.workspace = true
 home.workspace = true
+openssl.workspace = true
 rand = { version = "0.8", default-features = false }
 rpassword.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- bump `forc-wallet` to `0.16.4` after the failed `0.16.3` release attempt
- force vendored OpenSSL in `forc-wallet`, `forc-crypto`, and `forc-client` so the pending release binaries do not rely on system OpenSSL headers
- update changelogs and `Cargo.lock` to match the hotfix

## Validation
- `cargo build --locked --release -p forc-wallet`
- `cargo check --locked --all-features -p forc-crypto -p forc-client`
- `cargo tree -e features -p forc-wallet | rg 'openssl feature "vendored"|openssl-sys feature "vendored"'`

## Note
The exact local `cross build --profile=release --target aarch64-unknown-linux-gnu -p forc-wallet` could not be completed on this machine because the Docker daemon was unavailable here.