### PR TITLE
fix update releases workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Extract crate info from tag
         id: extract
@@ -377,7 +378,7 @@ jobs:
         run: ./.github/workflows/scripts/update_releases.sh ${{ steps.extract.outputs.crate_name }} ${{ steps.extract.outputs.version }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main

--- a/releases.toml
+++ b/releases.toml
@@ -44,3 +44,8 @@ sway = "0.70.3"
 fuel-core-types = "0.47.1"
 fuels-rs = "0.76.0"
 
+[[releases]]
+crate = "forc-wallet"
+version = "0.16.4"
+date = "2026-04-20"
+fuels-rs = "0.77.0"


### PR DESCRIPTION
## Summary

This fixes the `update-releases` workflow path that failed after the `forc-wallet v0.16.4` release and backfills the missing `releases.toml` entry that the failed automation never landed.

## Root cause

The failing run was the `Update releases.toml` job in CI run `24651220002`.

`actions/checkout@v6` persisted an auth header in the release-tag checkout, and `peter-evans/create-pull-request` added another one when it prepared the PR branch. During `git remote prune origin`, GitHub rejected the request with `400 Duplicate header: "Authorization"`, so the final PR-creation step failed even though the release metadata update itself succeeded.

## Changes

- set `persist-credentials: false` on the `Checkout release tag` step in `.github/workflows/ci.yml`
- upgrade `peter-evans/create-pull-request` from `v6` to `v8`
- add the missing `forc-wallet 0.16.4` entry to `releases.toml`

## Impact

Future release runs should be able to create the follow-up `releases.toml` PR without tripping over duplicate GitHub auth headers, and `main` regains the missing compatibility metadata for `forc-wallet 0.16.4`.

## Validation

- `git diff --check origin/main...HEAD`
- verified the failing GitHub Actions log for run `24651220002` and matched the workflow fix to the observed `Duplicate header: "Authorization"` error
