### PR TITLE
chore: update releases.toml for forc-client-0.71.3 and fix Slack notify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run Cargo.toml linter
         run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
       - name: Notify if Job Fails
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         if: always() && github.ref == 'refs/heads/master'
         with:
           status: ${{ job.status }}
@@ -125,7 +125,7 @@ jobs:
         env:
           RUSTFLAGS: "-D warnings"
       - name: Notify if Job Fails
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         if: always() && github.ref == 'refs/heads/master'
         with:
           status: ${{ job.status }}
@@ -174,7 +174,7 @@ jobs:
         run: cargo publish -p ${{ steps.extract_crate.outputs.crate_name }} --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Notify if Job Fails
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         if: always()
         with:
           status: ${{ job.status }}

--- a/releases.toml
+++ b/releases.toml
@@ -72,3 +72,11 @@ sway = "0.71.0"
 fuel-core-types = "0.48.0"
 fuels-rs = "0.77.0"
 
+[[releases]]
+crate = "forc-client"
+version = "0.71.3"
+date = "2026-05-26"
+sway = "0.71.2"
+fuel-core-types = "0.48.0"
+fuels-rs = "0.77.0"
+


### PR DESCRIPTION
## Summary

- Append `releases.toml` entry for `forc-client` 0.71.3 (sway 0.71.2, fuel-core-types 0.48.0, fuels-rs 0.77.0) — missed because the release workflow job failed after a successful publish
- Upgrade `ravsamhq/notify-slack-action` from `v1` to `v2` across CI jobs; v1 runs on Python 3.7 and crashes importing `functools.cache`, which incorrectly failed the `publish-crates` job even though `forc-client` 0.71.3 published successfully

## Test plan

- [ ] CI green
- [ ] Future release publish jobs complete without false failures on the Slack notify step